### PR TITLE
mobile-menu/bugfix/BodyScrolllock error

### DIFF
--- a/src/mobile-menu.js
+++ b/src/mobile-menu.js
@@ -7,9 +7,6 @@
     const isMenuOpen = openMenuBtn.getAttribute('aria-expanded') === 'true' || false;
     openMenuBtn.setAttribute('aria-expanded', !isMenuOpen);
     mobileMenu.classList.toggle('is-open');
-
-    const scrollLockMethod = !isMenuOpen ? 'disableBodyScroll' : 'enableBodyScroll';
-    bodyScrollLock[scrollLockMethod](document.body);
   };
 
   openMenuBtn.addEventListener('click', toggleMenu);
@@ -20,6 +17,5 @@
     if (!e.matches) return;
     mobileMenu.classList.remove('is-open');
     openMenuBtn.setAttribute('aria-expanded', false);
-    bodyScrollLock.enableBodyScroll(document.body);
   });
 })();


### PR DESCRIPTION
Wywalono blokadę scrollbara ze względu na to, że w niczym nie przeszkadza przewijanie strony, zwłaszcza że pewna jej część i tak jest widoczna